### PR TITLE
Submit2

### DIFF
--- a/test_exp_pipeline.sh
+++ b/test_exp_pipeline.sh
@@ -8,4 +8,4 @@ rm -r ./tmp_output/
 python main.py --max_train_iteration=100 --setting_file=./example/offline_setting/dla_exp_settings.json
 
 # Test model
-python main.py --test_only=True
+python main.py --test_only=True --setting_file=./example/offline_setting/dla_exp_settings.json

--- a/ultra/ranking_model/DNN.py
+++ b/ultra/ranking_model/DNN.py
@@ -63,7 +63,10 @@ class DNN(BaseRankingModel):
             output_sizes = self.hparams.hidden_layer_sizes + [1]
             current_size = output_data.get_shape()[-1].value
             for j in range(len(output_sizes)):
-                output_data=self.layer_norm[j](output_data,training=is_training)
+                if self.hparams.norm=="batch":
+                    output_data=self.layer_norm[j](output_data,training=is_training)
+                if self.hparams.norm=="layer":
+                    output_data=self.layer_norm[j](output_data) 
                 expand_W = tf.get_variable("dnn_W_%d" % j, [current_size, output_sizes[j]]) 
                 expand_b = tf.get_variable("dnn_b_%d" % j, [output_sizes[j]])
                 output_data = tf.nn.bias_add(tf.matmul(output_data, expand_W), expand_b)


### PR DESCRIPTION
1.During test, it seems we should also set the setting.json to construct layer.
2. only sent istraining when using batchnorm.  